### PR TITLE
Emit statistics from puzzle solver.

### DIFF
--- a/benches/main.rs
+++ b/benches/main.rs
@@ -1,5 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 use tsumego_solver::go::{BoardPosition, GoGame, Move};
+use tsumego_solver::puzzle::NoProfile;
 use tsumego_solver::puzzle::Puzzle;
 
 fn playing_moves(c: &mut Criterion) {
@@ -55,7 +56,11 @@ fn solving_puzzles(c: &mut Criterion) {
 
     simple.bench_function("1", |b| {
         b.iter_batched(
-            || Puzzle::from_sgf(include_str!("../src/test_sgfs/puzzles/true_simple1.sgf")),
+            || {
+                Puzzle::<NoProfile>::from_sgf(include_str!(
+                    "../src/test_sgfs/puzzles/true_simple1.sgf"
+                ))
+            },
             |mut puzzle| puzzle.solve(),
             BatchSize::SmallInput,
         )
@@ -63,7 +68,11 @@ fn solving_puzzles(c: &mut Criterion) {
 
     simple.bench_function("2", |b| {
         b.iter_batched(
-            || Puzzle::from_sgf(include_str!("../src/test_sgfs/puzzles/true_simple2.sgf")),
+            || {
+                Puzzle::<NoProfile>::from_sgf(include_str!(
+                    "../src/test_sgfs/puzzles/true_simple2.sgf"
+                ))
+            },
             |mut puzzle| puzzle.solve(),
             BatchSize::SmallInput,
         )
@@ -71,7 +80,11 @@ fn solving_puzzles(c: &mut Criterion) {
 
     simple.bench_function("3", |b| {
         b.iter_batched(
-            || Puzzle::from_sgf(include_str!("../src/test_sgfs/puzzles/true_simple3.sgf")),
+            || {
+                Puzzle::<NoProfile>::from_sgf(include_str!(
+                    "../src/test_sgfs/puzzles/true_simple3.sgf"
+                ))
+            },
             |mut puzzle| puzzle.solve(),
             BatchSize::SmallInput,
         )
@@ -84,7 +97,11 @@ fn solving_puzzles(c: &mut Criterion) {
 
     medium.bench_function("1", |b| {
         b.iter_batched(
-            || Puzzle::from_sgf(include_str!("../src/test_sgfs/puzzles/true_medium1.sgf")),
+            || {
+                Puzzle::<NoProfile>::from_sgf(include_str!(
+                    "../src/test_sgfs/puzzles/true_medium1.sgf"
+                ))
+            },
             |mut puzzle| puzzle.solve(),
             BatchSize::SmallInput,
         )

--- a/src/bin/cli/explore.rs
+++ b/src/bin/cli/explore.rs
@@ -7,20 +7,20 @@ use std::fs;
 use std::path::Path;
 use std::rc::Rc;
 use tsumego_solver::go::GoGame;
-use tsumego_solver::puzzle::Puzzle;
+use tsumego_solver::puzzle::{Profile, Puzzle};
 
-fn load_puzzle(filename: &str) -> Puzzle {
+fn load_puzzle(filename: &str) -> Puzzle<Profile> {
     let game = GoGame::from_sgf(&fs::read_to_string(Path::new(filename)).unwrap());
 
     Puzzle::new(game)
 }
 
-fn create_layer(puzzle_cell: Rc<RefCell<Puzzle>>) -> LinearLayout {
+fn create_layer(puzzle_cell: Rc<RefCell<Puzzle<Profile>>>) -> LinearLayout {
     let puzzle = puzzle_cell.borrow();
     let edges = puzzle.tree.edges(puzzle.current_node_id);
 
     let up_view = PaddedView::new(
-        Margins::lrtb(0, 0, 0, 2),
+        Margins::lrtb(0, 0, 1, 2),
         Button::new("Up", {
             let puzzle_cell = puzzle_cell.clone();
             move |s| {
@@ -50,7 +50,7 @@ fn create_layer(puzzle_cell: Rc<RefCell<Puzzle>>) -> LinearLayout {
     }
 
     let node_display = PaddedView::new(
-        Margins::lrtb(0, 0, 0, 2),
+        Margins::lr(0, 2),
         TextView::new(format!(
             "{:?}\n\n{}",
             puzzle.tree[puzzle.current_node_id],
@@ -58,10 +58,17 @@ fn create_layer(puzzle_cell: Rc<RefCell<Puzzle>>) -> LinearLayout {
         )),
     );
 
+    let middle = PaddedView::new(
+        Margins::lrtb(2, 2, 0, 2),
+        LinearLayout::horizontal()
+            .child(node_display)
+            .child(TextView::new(puzzle.profiler.print())),
+    );
+
     LinearLayout::vertical()
         .child(up_view)
-        .child(node_display)
-        .child(children)
+        .child(middle)
+        .child(PaddedView::new(Margins::lrtb(2, 0, 0, 1), children))
 }
 
 pub fn run(filename: &str) {

--- a/src/bin/cli/generate.rs
+++ b/src/bin/cli/generate.rs
@@ -6,6 +6,7 @@ use std::thread;
 use std::time::Duration;
 use tsumego_solver::generation::generate_puzzle;
 use tsumego_solver::go::GoBoard;
+use tsumego_solver::puzzle::NoProfile;
 
 pub fn run(output_directory: &Path, thread_count: u8) -> io::Result<()> {
     fs::create_dir_all(output_directory)?;
@@ -15,7 +16,7 @@ pub fn run(output_directory: &Path, thread_count: u8) -> io::Result<()> {
     for _ in 0..thread_count {
         let tx = tx.clone();
         thread::spawn(move || loop {
-            let puzzle = generate_puzzle(Duration::from_secs(1));
+            let puzzle = generate_puzzle::<NoProfile>(Duration::from_secs(1));
             tx.send(puzzle).unwrap();
         });
     }

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -2,17 +2,18 @@ mod candidate;
 mod validation;
 
 use crate::go::GoBoard;
+use crate::puzzle::Profiler;
 pub use candidate::generate_candidate;
 use std::time::Duration;
 pub use validation::validate_candidate;
 
-pub fn generate_puzzle(timeout: Duration) -> GoBoard {
+pub fn generate_puzzle<P: Profiler>(timeout: Duration) -> GoBoard {
     let mut rng = rand::thread_rng();
 
     loop {
         let candidate = generate_candidate(&mut rng);
 
-        if validate_candidate(candidate, timeout) {
+        if validate_candidate::<P>(candidate, timeout) {
             return candidate;
         }
     }

--- a/src/generation/validation.rs
+++ b/src/generation/validation.rs
@@ -1,14 +1,15 @@
 use crate::go::{GoBoard, GoGame, GoPlayer};
+use crate::puzzle::Profiler;
 use crate::puzzle::Puzzle;
 use std::time::Duration;
 
-pub fn validate_candidate(candidate: GoBoard, timeout: Duration) -> bool {
+pub fn validate_candidate<P: Profiler>(candidate: GoBoard, timeout: Duration) -> bool {
     if candidate.has_dead_groups() {
         return false;
     }
 
     GoPlayer::both().all(|first_player| {
-        let mut puzzle = Puzzle::new(GoGame::from_board(candidate, *first_player));
+        let mut puzzle = Puzzle::<P>::new(GoGame::from_board(candidate, *first_player));
 
         if !puzzle.solve_with_timeout(timeout) {
             return false;

--- a/src/puzzle/profiler.rs
+++ b/src/puzzle/profiler.rs
@@ -1,0 +1,60 @@
+pub trait Profiler {
+    fn new() -> Self;
+    fn move_up(&mut self);
+    fn move_down(&mut self);
+    fn add_nodes(&mut self, node_count: u8);
+}
+
+pub struct NoProfile;
+
+impl Profiler for NoProfile {
+    fn new() -> NoProfile {
+        NoProfile
+    }
+
+    fn move_up(&mut self) {}
+
+    fn move_down(&mut self) {}
+
+    fn add_nodes(&mut self, _node_count: u8) {}
+}
+
+pub struct Profile {
+    current_depth: u8,
+    pub max_depth: u8,
+    pub node_count: u32,
+}
+
+impl Profile {
+    pub fn print(&self) -> String {
+        format!(
+            "Max Depth: {}\nNode Count: {}\n",
+            self.max_depth, self.node_count
+        )
+    }
+}
+
+impl Profiler for Profile {
+    fn new() -> Profile {
+        Profile {
+            current_depth: 1,
+            max_depth: 1,
+            node_count: 1,
+        }
+    }
+
+    fn move_up(&mut self) {
+        self.current_depth -= 1;
+    }
+
+    fn move_down(&mut self) {
+        self.current_depth += 1;
+        if self.current_depth > self.max_depth {
+            self.max_depth = self.current_depth;
+        }
+    }
+
+    fn add_nodes(&mut self, node_count: u8) {
+        self.node_count += node_count as u32;
+    }
+}


### PR DESCRIPTION
The Puzzle type can optionally be configured to use a profiler by passing the `Profile` or `NoProfile` type parameter. If `NoProfile` is chosen, no runtime cost is incurred.

Currently, the following statistics are tracked:
* Maximum depth of tree.
* Number of nodes in the tree.

The unit tests for the puzzles also assert on these statistics to give an additional way of tracking changes in performance.

Closes #14.